### PR TITLE
Decompile APK from anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Open-source, cross platform [Qt6](https://www.qt.io/) based IDE for reverse-engi
 - Decompile/recompile/sign & install APKs
 - **Automatic tool download & installation** - APK Studio can automatically download and install required tools (Java, Apktool, JADX, ADB, Uber APK Signer)
 - **Framework support** - Install and use manufacturer-specific framework files (e.g., HTC, LG, Samsung) with optional tagging for decompiling and recompiling APKs
+- **Command-line APK opening** - Open APK files directly from the file system via "Open with" context menu or command-line arguments
 - Built-in code editor (\*.java; \*.smali; \*.xml; \*.yml) w/ syntax highlighting
 - Built-in viewer for image (\*.gif; \*.jpg; \*.jpeg; \*.png) files
 - Built-in hex editor for binary files
@@ -41,6 +42,8 @@ Open-source, cross platform [Qt6](https://www.qt.io/) based IDE for reverse-engi
 Please head over to [Releases](https://github.com/vaibhavpandeyvpz/apkstudio/releases) page for downloading.
 
 **Note:** APK Studio can automatically download and install required tools (Java, Apktool, JADX, ADB, Uber APK Signer) on first launch. If you prefer to use your own installations, you can configure them in Settings.
+
+**Tip:** You can open APK files directly from your file system by right-clicking an `.apk` file, selecting "Open with" → "Choose an app on your PC" (or "Choose another app"), then browsing to the APK Studio executable. Alternatively, you can pass the APK file path as a command-line argument. The decompile dialog will automatically open with the selected file.
 
 ### Building
 

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -1,8 +1,10 @@
 #include <QApplication>
+#include <QDir>
+#include <QFileInfo>
 #include <QSettings>
+#include <QStyleHints>
 #include <QTextStream>
 #include <QDateTime>
-#include <QStyleHints>
 #include "splashwindow.h"
 
 #define CODE_RESTART 60600
@@ -90,7 +92,17 @@ int main(int argc, char *argv[])
             app.setPalette(palette);
         #endif
 
-        SplashWindow window;
+        // Check for APK file path in command-line arguments
+        QString apkFilePath;
+        if (argc > 1) {
+            QString arg = QString::fromLocal8Bit(argv[1]);
+            QFileInfo fileInfo(arg);
+            if (fileInfo.exists() && fileInfo.suffix().toLower() == "apk") {
+                apkFilePath = QDir::toNativeSeparators(fileInfo.absoluteFilePath());
+            }
+        }
+        
+        SplashWindow window(apkFilePath);
         window.show();
         code = app.exec();
     } while (code == CODE_RESTART);

--- a/sources/mainwindow.h
+++ b/sources/mainwindow.h
@@ -26,6 +26,7 @@ public:
     };
     explicit MainWindow(const QMap<QString, QString> &versions, QWidget *parent = nullptr);
     ~MainWindow();
+    void openApkFile(const QString &apkPath);
 protected:
     void closeEvent(QCloseEvent *event);
 private:

--- a/sources/splashwindow.cpp
+++ b/sources/splashwindow.cpp
@@ -14,8 +14,8 @@
 #define SPLASH_WIDTH 512
 #define SPLASH_HEIGHT 320
 
-SplashWindow::SplashWindow()
-    : QMainWindow(nullptr, Qt::SplashScreen)
+SplashWindow::SplashWindow(const QString &apkFilePath)
+    : QMainWindow(nullptr, Qt::SplashScreen), m_ApkFilePath(apkFilePath)
 {
     setCentralWidget(buildCentralWidget());
     setFixedSize(SPLASH_WIDTH, SPLASH_HEIGHT);
@@ -75,7 +75,14 @@ void SplashWindow::handleVersionResolved(const QString &binary, const QString &v
 
 void SplashWindow::handleVersionResolveFinished()
 {
-    (new MainWindow(m_Versions))->show();
+    auto mainWindow = new MainWindow(m_Versions);
+    mainWindow->show();
+    // If APK file was passed via command line, automatically open decompile dialog
+    if (!m_ApkFilePath.isEmpty()) {
+        QTimer::singleShot(100, [mainWindow, this]() {
+            mainWindow->openApkFile(m_ApkFilePath);
+        });
+    }
     close();
 }
 

--- a/sources/splashwindow.h
+++ b/sources/splashwindow.h
@@ -9,10 +9,11 @@ class SplashWindow : public QMainWindow
 {
     Q_OBJECT
 public:
-    SplashWindow();
+    explicit SplashWindow(const QString &apkFilePath = QString());
     ~SplashWindow();
 private:
     QMap<QString, QString> m_Versions;
+    QString m_ApkFilePath;
     QWidget *buildCentralWidget();
 private slots:
     void handleVersionResolved(const QString &binary, const QString &version);


### PR DESCRIPTION
# Add Command-Line APK Opening Support

## Summary

Adds support for opening APK files directly from the file system via command-line arguments or "Open with" context menu.

## Changes

- Parse command-line arguments in `main()` to detect APK file paths
- Pass APK file path from `SplashWindow` to `MainWindow`
- Automatically open decompile dialog when APK file is provided via command line
- Added `openApkFile()` public method to `MainWindow` for programmatic APK opening

## Usage

Users can now:
- Right-click an `.apk` file → "Open with" → Choose APK Studio
- Pass APK file path as command-line argument: `ApkStudio.exe path/to/file.apk`

The decompile dialog will automatically open with the selected file after application initialization.
