### PR TITLE
Pass additional (optional) args to apktool

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Open-source, cross platform [Qt6](https://www.qt.io/) based IDE for reverse-engi
 - **Automatic tool download & installation** - APK Studio can automatically download and install required tools (Java, Apktool, JADX, ADB, Uber APK Signer)
 - **Framework support** - Install and use manufacturer-specific framework files (e.g., HTC, LG, Samsung) with optional tagging for decompiling and recompiling APKs
 - **Command-line APK opening** - Open APK files directly from the file system via "Open with" context menu or command-line arguments
+- **Extra apktool arguments** - Provide additional command-line arguments (e.g., `--force-all`, `--no-res`) for decompile and recompile operations
 - **Search functionality** - Quick search in open files and project tree to find items by name
 - Built-in code editor (\*.java; \*.smali; \*.xml; \*.yml) w/ syntax highlighting
 - Built-in viewer for image (\*.gif; \*.jpg; \*.jpeg; \*.png) files

--- a/sources/apkdecompiledialog.cpp
+++ b/sources/apkdecompiledialog.cpp
@@ -14,7 +14,7 @@ ApkDecompileDialog::ApkDecompileDialog(const QString &apk, QWidget *parent)
     layout->addWidget(buildButtonBox());
     layout->setContentsMargins(4, 4, 4, 4);
     layout->setSpacing(2);
-    setMinimumSize(340, 160);
+    setMinimumSize(340, 200);
 #ifdef Q_OS_WIN
     setWindowIcon(QIcon(":/icons/fugue/android.png"));
 #endif
@@ -59,6 +59,9 @@ QLayout *ApkDecompileDialog::buildForm(const QString &apk)
     layout->addRow(tr("Framework tag (optional)"), m_EditFrameworkTag = new QLineEdit(this));
     m_EditFrameworkTag->setPlaceholderText(tr("e.g., hero, desire, samsung"));
     m_EditFrameworkTag->setToolTip(tr("Specify a framework tag if you installed frameworks with a tag. Leave empty to use default framework."));
+    layout->addRow(tr("Extra arguments (optional)"), m_EditExtraArguments = new QLineEdit(this));
+    m_EditExtraArguments->setPlaceholderText(tr("e.g., --force-all, --no-res"));
+    m_EditExtraArguments->setToolTip(tr("Additional apktool command-line arguments. Separate multiple arguments with spaces."));
     layout->setSpacing(2);
     return layout;
 }
@@ -98,4 +101,9 @@ bool ApkDecompileDialog::smali() const
 QString ApkDecompileDialog::frameworkTag() const
 {
     return m_EditFrameworkTag->text().trimmed();
+}
+
+QString ApkDecompileDialog::extraArguments() const
+{
+    return m_EditExtraArguments->text().trimmed();
 }

--- a/sources/apkdecompiledialog.h
+++ b/sources/apkdecompiledialog.h
@@ -17,6 +17,7 @@ public:
     bool resources() const;
     bool smali() const;
     QString frameworkTag() const;
+    QString extraArguments() const;
 private:
     QDialogButtonBox *m_ButtonBox;
     QCheckBox *m_CheckJava;
@@ -25,6 +26,7 @@ private:
     QLineEdit *m_EditApk;
     QLineEdit *m_EditFolder;
     QLineEdit *m_EditFrameworkTag;
+    QLineEdit *m_EditExtraArguments;
     QWidget *buildButtonBox();
     QLayout *buildForm(const QString &apk);
 private slots:

--- a/sources/apkdecompileworker.cpp
+++ b/sources/apkdecompileworker.cpp
@@ -1,9 +1,10 @@
 #include <QDebug>
+#include <QRegularExpression>
 #include "apkdecompileworker.h"
 #include "processutils.h"
 
-ApkDecompileWorker::ApkDecompileWorker(const QString &apk, const QString &folder, const bool smali, const bool resources, const bool java, const QString &frameworkTag, QObject *parent)
-    : QObject(parent), m_Apk(apk), m_Folder(folder), m_Java(java), m_Resources(resources), m_Smali(smali), m_FrameworkTag(frameworkTag)
+ApkDecompileWorker::ApkDecompileWorker(const QString &apk, const QString &folder, const bool smali, const bool resources, const bool java, const QString &frameworkTag, const QString &extraArguments, QObject *parent)
+    : QObject(parent), m_Apk(apk), m_Folder(folder), m_Java(java), m_Resources(resources), m_Smali(smali), m_FrameworkTag(frameworkTag), m_ExtraArguments(extraArguments)
 {
 }
 
@@ -33,6 +34,11 @@ void ApkDecompileWorker::decompile()
     }
     if (!m_FrameworkTag.isEmpty()) {
         args << "-t" << m_FrameworkTag;
+    }
+    // Parse and add extra arguments
+    if (!m_ExtraArguments.isEmpty()) {
+        QStringList extraArgs = m_ExtraArguments.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+        args << extraArgs;
     }
     args << "-o" << m_Folder << m_Apk;
     ProcessResult result = ProcessUtils::runCommand(java, args);

--- a/sources/apkdecompileworker.h
+++ b/sources/apkdecompileworker.h
@@ -7,7 +7,7 @@ class ApkDecompileWorker : public QObject
 {
     Q_OBJECT
 public:
-    explicit ApkDecompileWorker(const QString &apk, const QString &folder, const bool smali, const bool resources, const bool java, const QString &frameworkTag = QString(), QObject *parent = nullptr);
+    explicit ApkDecompileWorker(const QString &apk, const QString &folder, const bool smali, const bool resources, const bool java, const QString &frameworkTag = QString(), const QString &extraArguments = QString(), QObject *parent = nullptr);
     void decompile();
 private:
     QString m_Apk;
@@ -16,6 +16,7 @@ private:
     bool m_Resources;
     bool m_Smali;
     QString m_FrameworkTag;
+    QString m_ExtraArguments;
 signals:
     void decompileFailed(const QString &apk);
     void decompileFinished(const QString &apk, const QString &folder);

--- a/sources/apkrecompileworker.cpp
+++ b/sources/apkrecompileworker.cpp
@@ -1,9 +1,10 @@
 #include <QDebug>
+#include <QRegularExpression>
 #include "apkrecompileworker.h"
 #include "processutils.h"
 
-ApkRecompileWorker::ApkRecompileWorker(const QString &folder, bool aapt2, QObject *parent)
-    : QObject(parent), m_Aapt2(aapt2), m_Folder(folder)
+ApkRecompileWorker::ApkRecompileWorker(const QString &folder, bool aapt2, const QString &extraArguments, QObject *parent)
+    : QObject(parent), m_Aapt2(aapt2), m_Folder(folder), m_ExtraArguments(extraArguments)
 {
 }
 
@@ -27,6 +28,11 @@ void ApkRecompileWorker::recompile()
     // Apktool 2.12.1+ uses aapt2 by default, so we only need to specify --use-aapt1 if aapt1 is requested
     if (!m_Aapt2) {
         args << "--use-aapt1";
+    }
+    // Parse and add extra arguments
+    if (!m_ExtraArguments.isEmpty()) {
+        QStringList extraArgs = m_ExtraArguments.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+        args << extraArgs;
     }
     ProcessResult result = ProcessUtils::runCommand(java, args);
 #ifdef QT_DEBUG

--- a/sources/apkrecompileworker.h
+++ b/sources/apkrecompileworker.h
@@ -7,11 +7,12 @@ class ApkRecompileWorker : public QObject
 {
     Q_OBJECT
 public:
-    explicit ApkRecompileWorker(const QString &folder, bool aapt2, QObject *parent = nullptr);
+    explicit ApkRecompileWorker(const QString &folder, bool aapt2, const QString &extraArguments = QString(), QObject *parent = nullptr);
     void recompile();
 private:
     bool m_Aapt2;
     QString m_Folder;
+    QString m_ExtraArguments;
 signals:
     void finished();
     void recompileFailed(const QString &folder);

--- a/sources/mainwindow.h
+++ b/sources/mainwindow.h
@@ -13,6 +13,7 @@
 #include <QSortFilterProxyModel>
 #include <QStandardItemModel>
 #include <QTextEdit>
+#include <QToolBar>
 #include <QTreeWidget>
 #include <QVBoxLayout>
 #include "findreplacedialog.h"
@@ -32,6 +33,7 @@ public:
     void openApkFile(const QString &apkPath);
 protected:
     void closeEvent(QCloseEvent *event);
+    bool eventFilter(QObject *obj, QEvent *event) override;
 private:
     QAction *m_ActionBuild1;
     QAction *m_ActionBuild2;
@@ -53,6 +55,7 @@ private:
     QAction *m_ActionViewProject;
     QAction *m_ActionViewFiles;
     QAction *m_ActionViewConsole;
+    QAction *m_ActionViewToolBar;
     QStackedWidget *m_CentralStack;
     QDockWidget *m_DockProject;
     QDockWidget *m_DockFiles;
@@ -64,6 +67,7 @@ private:
     QLineEdit *m_SearchFiles;
     QLineEdit *m_SearchProjects;
     QListView *m_ListOpenFiles;
+    QToolBar *m_MainToolBar;
     QStandardItemModel *m_ModelOpenFiles;
     QSortFilterProxyModel *m_FilesProxyModel;
     QProgressDialog *m_ProgressDialog;


### PR DESCRIPTION
## Summary

Adds support for providing additional command-line arguments to apktool during decompile and recompile operations.

## Changes

- Added "Extra arguments (optional)" field in decompile dialog
- Added input dialog for extra arguments when building/recompiling
- Arguments are parsed and appended to apktool command
- Updated `ApkDecompileWorker` and `ApkRecompileWorker` to accept and use extra arguments

## Usage

- **Decompile**: Enter extra arguments in decompile dialog (e.g., `--force-all --no-res`)
- **Recompile**: Provide extra arguments when prompted during build (optional, can be cancelled)