### PR TITLE
Fix dock state saving during minimize

### DIFF
--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
         #else
             // Fallback for Qt 6.0-6.4: manually set palette
             QPalette palette;
-            if (dark) {
+        if (dark) {
                 palette.setColor(QPalette::Window, QColor(53, 53, 53));
                 palette.setColor(QPalette::WindowText, Qt::white);
                 palette.setColor(QPalette::Base, QColor(25, 25, 25));
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
             QFileInfo fileInfo(arg);
             if (fileInfo.exists() && fileInfo.suffix().toLower() == "apk") {
                 apkFilePath = QDir::toNativeSeparators(fileInfo.absoluteFilePath());
-            }
+        }
         }
         
         SplashWindow window(apkFilePath);

--- a/sources/mainwindow.cpp
+++ b/sources/mainwindow.cpp
@@ -311,19 +311,36 @@ QMenuBar *MainWindow::buildMenuBar()
     m_ActionViewProject = view->addAction(tr("Project"));
     m_ActionViewProject->setCheckable(true);
     connect(m_ActionViewProject, &QAction::toggled, m_DockProject, &QDockWidget::setVisible);
-    connect(m_DockProject, &QDockWidget::visibilityChanged, m_ActionViewProject, &QAction::setChecked);
+    connect(m_DockProject, &QDockWidget::visibilityChanged, [this](bool isVisible) {
+        if (!(windowState() & Qt::WindowMinimized)) {
+            m_ActionViewProject->setChecked(isVisible);
+        }
+    });
     m_ActionViewFiles = view->addAction(tr("Files"));
     m_ActionViewFiles->setCheckable(true);
     connect(m_ActionViewFiles, &QAction::toggled, m_DockFiles, &QDockWidget::setVisible);
-    connect(m_DockFiles, &QDockWidget::visibilityChanged, m_ActionViewFiles, &QAction::setChecked);
+    connect(m_DockFiles, &QDockWidget::visibilityChanged, [this](bool isVisible) {
+        if (!(windowState() & Qt::WindowMinimized)) {
+            m_ActionViewFiles->setChecked(isVisible);
+        }
+    });
     m_ActionViewConsole = view->addAction(tr("Console"));
     m_ActionViewConsole->setCheckable(true);
     connect(m_ActionViewConsole, &QAction::toggled, m_DockConsole, &QDockWidget::setVisible);
-    connect(m_DockConsole, &QDockWidget::visibilityChanged, m_ActionViewConsole, &QAction::setChecked);
+    connect(m_DockConsole, &QDockWidget::visibilityChanged, [this](bool isVisible) {
+        if (!(windowState() & Qt::WindowMinimized)) {
+            m_ActionViewConsole->setChecked(isVisible);
+        }
+    });
     view->addSeparator();
     m_ActionViewToolBar = view->addAction(tr("Sidebar"));
     m_ActionViewToolBar->setCheckable(true);
     connect(m_ActionViewToolBar, &QAction::toggled, m_MainToolBar, &QToolBar::setVisible);
+    connect(m_MainToolBar, &QToolBar::visibilityChanged, [this](bool isVisible) {
+        if (!(windowState() & Qt::WindowMinimized)) {
+            m_ActionViewToolBar->setChecked(isVisible);
+        }
+    });
     auto project = menubar->addMenu(tr("Project"));
     m_ActionBuild1 = project->addAction(tr("Build"), this, &MainWindow::handleActionBuild);
     m_ActionBuild1->setEnabled(false);


### PR DESCRIPTION
# Fix Dock Widgets Disappearing on Minimize/Restore

## Summary

Fixes an issue where dock widgets (Project, Files, Console) would disappear after minimizing and restoring the main window.

## Changes

- Prevent menu action checked states from updating when window is minimized
- This preserves the dock visibility state during minimize/restore cycle

## Technical Details

When the window is minimized, Qt hides the dock widgets, which triggers `visibilityChanged` signals. These signals were updating the menu actions to unchecked, so when the window was restored, the docks remained hidden. The fix prevents menu action updates when the window is minimized, preserving their checked state.
